### PR TITLE
Copied javax.validation.api sources.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.0</version>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-gwt-internal-annotations</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-uber</artifactId>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -282,6 +287,47 @@
                         <scope>compile</scope>
                     </dependency>
                 </dependencies>
+            </plugin>
+
+            <!-- transpile task will fail because entry-point is missing, stil moderately useful-->
+            <plugin>
+                <groupId>walkingkooka</groupId>
+                <artifactId>j2cl-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+
+                <executions>
+                    <execution>
+                        <id>build</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <classpath-scope>runtime</classpath-scope>
+                            <compilation-level>SIMPLE</compilation-level>
+                            <defines>
+                                <gwt.cspCompatModeEnabled>true</gwt.cspCompatModeEnabled>
+                                <gwt.enableDebugId>true</gwt.enableDebugId>
+                                <gwt.strictCspTestingEnabled>true</gwt.strictCspTestingEnabled>
+                                <jre.checkedMode>DISABLED</jre.checkedMode>
+                                <jre.checks.checkLevel>MINIMAL</jre.checks.checkLevel>
+                                <jsinterop.checks>DISABLED</jsinterop.checks>
+                            </defines>
+                            <entry-points/>
+                            <externs></externs>
+                            <formatting>
+                                <param>PRETTY_PRINT</param>
+                            </formatting>
+                            <java-compiler-arguments/>
+                            <language-out>ECMASCRIPT_2016</language-out>
+                            <source-maps>sources/</source-maps>
+                            <thread-pool-size>1</thread-pool-size>
+
+                            <classpath-required/>
+                            <ignored-dependencies/>
+                            <javascript-source-required/>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
+++ b/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
@@ -1,0 +1,12 @@
+#
+# Contains references to numerous unimplemented JRE classes.
+#
+javax/validation/Validation.*
+
+#
+# Uses the un-emulated RegExp class(es).
+#
+javax/validation/constraints/Pattern.*
+
+
+


### PR DESCRIPTION
- Validation & Pattern @GwtIncompatible
- Note Validation annotations are not honoured.
- Consider this a non functional but transpilable stub.